### PR TITLE
Added test

### DIFF
--- a/Tests/test_file_apng.py
+++ b/Tests/test_file_apng.py
@@ -433,7 +433,9 @@ def test_apng_save_duration_loop(tmp_path):
 
     # test removal of duplicated frames
     frame = Image.new("RGBA", (128, 64), (255, 0, 0, 255))
-    frame.save(test_file, save_all=True, append_images=[frame], duration=[500, 250])
+    frame.save(
+        test_file, save_all=True, append_images=[frame, frame], duration=[500, 100, 150]
+    )
     with Image.open(test_file) as im:
         im.load()
         assert im.n_frames == 1

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -1117,12 +1117,12 @@ def _write_multiple_frames(im, fp, chunk, rawmode):
                     and prev_disposal == encoderinfo.get("disposal")
                     and prev_blend == encoderinfo.get("blend")
                 ):
-                    now_duration = encoderinfo.get("duration", 0)
-                    if now_duration:
+                    frame_duration = encoderinfo.get("duration", 0)
+                    if frame_duration:
                         if "duration" in previous["encoderinfo"]:
-                            previous["encoderinfo"]["duration"] += now_duration
+                            previous["encoderinfo"]["duration"] += frame_duration
                         else:
-                            previous["encoderinfo"]["duration"] = now_duration
+                            previous["encoderinfo"]["duration"] = frame_duration
                     continue
             else:
                 bbox = None


### PR DESCRIPTION
Two suggestions for https://github.com/python-pillow/Pillow/pull/5609

1. Renames the variable from `now_duration` to `frame_duration`.
2. Updates a test so that the test suite now fails without the PR, and passes with it. This helps us to avoid re-introducing this problem in the future by accident.